### PR TITLE
upgrade Python ACRO backend to v0.4.7

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,12 +1,12 @@
 Package: acro
 Title: A Tool for Automating the Statistical Disclosure Control of Research Outputs
-Version: 0.1.2
+Version: 0.1.3
 Authors@R: c(
   person("Jim", "Smith", role = c("cre","ctb"),
          email = "James.Smith@uwe.ac.uk", comment = c(ORCID = "0000-0001-7908-1859")),
   person("Maha", "Albashir", role = c("aut","ctb"),
          email = "Maha.Albashir@uwe.ac.uk"),
-  person("Richard John", "Preen", role = c("ctb"),
+  person("Richard John", "Preen", role = c("aut","ctb"),
          email = "Richard2.Preen@uwe.ac.uk", comment = c(ORCID = "0000-0003-3351-8132")))
 Maintainer: Jim Smith <James.Smith@uwe.ac.uk>
 Description: Assists researchers and output checkers by distinguishing between research output that is safe to publish, output that requires further analysis, and output that cannot be published because of substantial disclosure risk. A paper about the tool was presented at the UNECE Expert Meeting on Statistical Data Confidentiality 2023; see <https://uwe-repository.worktribe.com/output/11060964>.
@@ -14,7 +14,7 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
-SystemRequirements: Python (>= 3.8)
+SystemRequirements: Python (>= 3.9)
 Imports:
     reticulate,
     admiraldev,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# acro 0.1.3
+
+* Upgrade ACRO Python backend to v0.4.7, supporting pandas v2 for a more seamless installation with Python 3.12.
+
 # acro 0.1.2
 
 ## Bug fixes

--- a/R/create_virtualenv.R
+++ b/R/create_virtualenv.R
@@ -1,6 +1,6 @@
-acro_venv <- "r-acro-0.4.6"
-acro_package <- "acro==0.4.6"
-python_version <- ">=3.8"
+acro_venv <- "r-acro-0.4.7"
+acro_package <- "acro==0.4.7"
+python_version <- ">=3.9"
 
 
 #' Install acro

--- a/README.md
+++ b/README.md
@@ -5,25 +5,16 @@
 [![check](https://github.com/AI-SDC/ACRO-R/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/AI-SDC/ACRO-R/actions?query=workflow%3AR-CMD-check)
 [![codecov](https://codecov.io/gh/AI-SDC/ACRO-R/graph/badge.svg?token=VxbjBHzeXU)](https://app.codecov.io/gh/AI-SDC/ACRO-R)
 
-This repository maintains the ACRO R package, which is an interface to the
-Python [ACRO](https://github.com/AI-SDC/ACRO) package.
+This repository maintains the ACRO R package, which is an interface to the Python [ACRO](https://github.com/AI-SDC/ACRO) package.
 
-ACRO (Automatic Checking of Research Outputs) is an open source
-tool for automating the statistical disclosure control (SDC) of research
-outputs. ACRO assists researchers and output checkers by distinguishing between
-research output that is safe to publish, output that requires further analysis,
-and output that cannot be published because of substantial disclosure risk.
+ACRO (Automatic Checking of Research Outputs) is an open source tool for automating the [statistical disclosure control](https://en.wikipedia.org/wiki/Statistical_disclosure_control) (SDC) of research outputs. ACRO assists researchers and output checkers by distinguishing between research output that is safe to publish, output that requires further analysis, and output that cannot be published because of a substantial risk of disclosing private data.
 
-It does this by providing a light-weight 'skin' that sits over well-known
-analysis tools, in a variety of languages researchers might use. This adds
-functionality to:
+It does this by providing a light-weight 'skin' that sits over well-known analysis tools, in a variety of languages researchers might use. This adds functionality to:
 
-*   identify potentially disclosive outputs against a range of commonly used
-    disclosure tests;
+*   identify potentially disclosive outputs against a range of commonly used disclosure tests;
 *   suppress outputs where required;
 *   report reasons for suppression;
-*   produce simple summary documents TRE staff can use to streamline their
-    workflow.
+*   produce simple summary documents TRE staff can use to streamline their workflow.
 
 ### Installation
 
@@ -33,11 +24,11 @@ Install the **acro** package from CRAN as follows:
 install.packages("acro")
 ```
 
-#### Notes for Python 3.12
+#### Notes for Python 3.13
 
-ACRO currently depends on an older version of Pandas (~1.5.0) for which no pre-compiled wheels are available within pip for Python 3.12. Therefore, in this scenario, Pandas must be built from source. This requires the installation of a C++ compiler before pip installing acro. Earlier Python versions do not have this issue.
+ACRO currently depends on numpy version 1.x.x for which no pre-compiled wheels are available within pip for Python 3.13. Therefore, in this scenario, numpy must be built from source. This requires the installation of a C++ compiler before pip installing acro.
 
-For Windows, [Microsoft Visual Studio](https://visualstudio.microsoft.com/downloads/) and the [C++ build tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) will likely need to be installed first.
+For Windows, the [Microsoft Visual Studio C++ build tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) will likely need to be installed first.
 
 If you are unable to install the C++ tools, but are able to install multiple versions of Python, you can use the following method to explicitly create the Python virtual environment with your desired `python.exe`.
 
@@ -47,8 +38,8 @@ Then from R, use reticulate to create the virtual environment and install ACRO; 
 
 ```R
 >>> library("reticulate")
->>> reticulate::virtualenv_create(envname = "r-acro-0.4.6", version = "C:/Users/username/AppData/Local/Programs/Python/Python310/python.exe", force = TRUE, packages = NULL)
->>> reticulate::py_install("acro", envname = "r-acro-0.4.6")
+>>> reticulate::virtualenv_create(envname = "r-acro-0.4.7", version = "C:/Users/username/AppData/Local/Programs/Python/Python310/python.exe", force = TRUE, packages = NULL)
+>>> reticulate::py_install("acro", envname = "r-acro-0.4.7")
 ```
 
 Finally, the R ACRO library can be used as normal:
@@ -60,8 +51,7 @@ Finally, the R ACRO library can be used as normal:
 
 ### Usage
 
-Before using any function from the package, an acro object should be
-initialised using the following R code:
+Before using any function from the package, an acro object should be initialised using the following R code:
 
 ``` r
 >>> library("acro")
@@ -70,16 +60,12 @@ initialised using the following R code:
 
 Then the functions can be called.
 
+### Documentation
+
+The github-pages contains pre-built [documentation](https://ai-sdc.github.io/ACRO-R/).
+
 ### Acknowledgement
 
-This work was funded by UK Research and Innovation under Grant Numbers
-MC_PC_21033 and MC_PC_23006 as part of Phase 1 of the Data and Analytics
-Research Environments UK ([DARE UK](https://dareuk.org.uk/)) programme,
-delivered in partnership with Health Data Research UK (HDR UK) and
-Administrative Data Research UK (ADR UK). The specific projects were
-Semi-Automatic checking of Research Outputs (SACRO; MC_PC_23006) and Guidelines
-and Resources for AI Model Access from Trusted Research environments
-(GRAIMATTER; MC_PC_21033). This project has also been supported by MRC and
-EPSRC [grant number MR/S010351/1].
+This work was funded by UK Research and Innovation under Grant Numbers MC_PC_21033 and MC_PC_23006 as part of Phase 1 of the Data and Analytics Research Environments UK ([DARE UK](https://dareuk.org.uk/)) programme, delivered in partnership with Health Data Research UK (HDR UK) and Administrative Data Research UK (ADR UK). The specific projects were Semi-Automatic checking of Research Outputs (SACRO; MC_PC_23006) and Guidelines and Resources for AI Model Access from Trusted Research environments (GRAIMATTER; MC_PC_21033). This project has also been supported by MRC and EPSRC [grant number MR/S010351/1].
 
 <img src="inst/Images/UK_Research_and_Innovation_logo.svg" alt="Alt Text" width="20%"> <img src="inst/Images/health-data-research-uk-hdr-uk-logo-vector.png" alt="Alt Text" width="20%"> <img src="inst/Images/logo_print.png" alt="Alt Text" width="20%">


### PR DESCRIPTION
Upgrades the Python ACRO backend to v0.4.7, which supports Pandas >=2 and therefore provides a more seamless installation for Python 3.12 users.