### PR TITLE
ci: added git-cliff changelog automation

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -24,5 +24,6 @@
 ^\.vscode$
 ^.*\.swp$
 ^\.Rdata$
+^cliff\.toml$
 ^doc$
 ^Meta$

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,7 +128,7 @@ The configuration lives in `cliff.toml` at the repository root. It automatically
 
 - Converts `(#NNN)` PR references into markdown links.
 - Skips noise commits (pre-commit auto-fixes, changelog and release-prep commits).
-- Filters out commits that do not follow Conventional Commits (see [Pull Request Titles](#pull-request-titles)).
+- Groups commits that do not follow Conventional Commits under an "Other" heading so nothing is dropped (see [Pull Request Titles](#pull-request-titles)).
 
 ## CRAN Submission
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,62 @@ writeLines(pak::pkg_system_requirements("devtools", "ubuntu", "22.04"))
 To remove the local virtual Python environment, delete the `r-acro` folder.
 On GNU/Linux this is typically located in `~/.virtualenvs`
 
+## Pull Request Titles
+
+Use [Conventional Commits](https://www.conventionalcommits.org) for PR titles (squash-merge messages). This allows automated changelog generation. Common prefixes:
+
+```
+feat — new feature
+fix — bug fix
+docs — documentation changes
+style — formatting/styling (no code logic)
+refactor — code changes without feature/bug impact
+perf — performance improvements
+test — adding/updating tests
+build — changes to build system or dependencies
+ci — changes to CI config/scripts
+chore — miscellaneous maintenance tasks
+revert — reverts an earlier commit
+```
+
+## Release Workflow
+
+`NEWS.md` is generated locally before each release using [git-cliff](https://github.com/orhun/git-cliff). It reads merged PR titles (via squash-merge commit messages) since the last release tag and formats them to match the existing changelog style.
+
+### Install git-cliff
+
+Download a prebuilt binary from the [releases page](https://github.com/orhun/git-cliff/releases) or install via a package manager:
+
+```shell
+# homebrew (macOS / Linux)
+brew install git-cliff
+
+# winget (Windows)
+winget install git-cliff
+```
+
+### Generate the changelog entry
+
+Run the following on `main` immediately before tagging a new release, replacing `X.Y.Z` with the new version:
+
+```shell
+git cliff --config cliff.toml --unreleased --tag "VX.Y.Z" --prepend NEWS.md
+```
+
+Review and edit `NEWS.md` as needed (e.g. to add extra context or merge duplicate entries), then commit:
+
+```shell
+git add NEWS.md
+git commit -m "docs: update changelog"
+git tag VX.Y.Z
+```
+
+The configuration lives in `cliff.toml` at the repository root. It automatically:
+
+- Converts `(#NNN)` PR references into markdown links.
+- Skips noise commits (pre-commit auto-fixes, changelog and release-prep commits).
+- Filters out commits that do not follow Conventional Commits (see [Pull Request Titles](#pull-request-titles)).
+
 ## CRAN Submission
 
 A useful command to run before submitting:

--- a/R/acro_init.R
+++ b/R/acro_init.R
@@ -33,7 +33,8 @@ install_conda <- function(envname) { # nocov
 # Internal helper: install ACRO in a Python virtual environment
 install_venv <- function(envname = acro_venv) {
   if (!reticulate::virtualenv_exists(envname)) {
-    python <- reticulate::virtualenv_starter() %||% get_python()
+    python <- reticulate::virtualenv_starter()
+    if (is.null(python)) python <- get_python()
 
     reticulate::virtualenv_create(
       envname = envname,

--- a/R/acro_init.R
+++ b/R/acro_init.R
@@ -33,7 +33,7 @@ install_conda <- function(envname) { # nocov
 # Internal helper: install ACRO in a Python virtual environment
 install_venv <- function(envname = acro_venv) {
   if (!reticulate::virtualenv_exists(envname)) {
-    python <- get_python()
+    python <- reticulate::virtualenv_starter() %||% get_python()
 
     reticulate::virtualenv_create(
       envname = envname,

--- a/R/acro_init.R
+++ b/R/acro_init.R
@@ -34,7 +34,7 @@ install_conda <- function(envname) { # nocov
 install_venv <- function(envname = acro_venv) {
   if (!reticulate::virtualenv_exists(envname)) {
     python <- reticulate::virtualenv_starter()
-    if (is.null(python)) python <- get_python()
+    if (is.null(python)) python <- get_python() # nocov
 
     reticulate::virtualenv_create(
       envname = envname,

--- a/R/acro_init.R
+++ b/R/acro_init.R
@@ -33,8 +33,7 @@ install_conda <- function(envname) { # nocov
 # Internal helper: install ACRO in a Python virtual environment
 install_venv <- function(envname = acro_venv) {
   if (!reticulate::virtualenv_exists(envname)) {
-    python <- reticulate::virtualenv_starter()
-    if (is.null(python)) python <- get_python() # nocov
+    python <- get_python()
 
     reticulate::virtualenv_create(
       envname = envname,

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,46 @@
+[changelog]
+header = ""
+body = """
+{% if version %}\
+# acro {{ version | trim_start_matches(pat="V") }} ({{ timestamp | date(format="%b %d, %Y") }})
+{% else %}\
+# Unreleased
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group }}
+{% for commit in commits -%}
+*   {% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ commit.message | trim }}
+{% endfor %}
+{%- endfor %}\
+"""
+trim = true
+footer = ""
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+# Only matches uppercase V tags (V0.1.7+); older lowercase tags
+# (v0.1.1–v0.1.6) are excluded — their NEWS.md entries were hand-written.
+tag_pattern = "V[0-9]+\\.[0-9]+\\.[0-9]+"
+
+commit_preprocessors = [
+    { pattern = ' \(#(\d+)\)', replace = ' ([#$1](https://github.com/AI-SDC/ACRO-R/pull/$1))' },
+]
+
+commit_parsers = [
+    { message = "^\\[pre-commit", skip = true },
+    { message = "^docs: update changelog", skip = true },
+    { message = "^docs: update citation", skip = true },
+    { message = "^chore: prepare", skip = true },
+    { message = "^feat", group = "feat" },
+    { message = "^fix", group = "fix" },
+    { message = "^docs", group = "docs" },
+    { message = "^perf", group = "perf" },
+    { message = "^refactor", group = "refactor" },
+    { message = "^build", group = "build" },
+    { message = "^test", group = "test" },
+    { message = "^ci", group = "ci" },
+    { message = "^style", group = "style" },
+    { message = "^chore", group = "chore" },
+    { message = "^revert", group = "revert" },
+]

--- a/cliff.toml
+++ b/cliff.toml
@@ -11,20 +11,22 @@ body = """
 {% for commit in commits -%}
 *   {% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ commit.message | trim }}
 {% endfor %}
-{%- endfor %}\
+{%- endfor %}
 """
-trim = true
+trim = false
 footer = ""
 
 [git]
 conventional_commits = true
-filter_unconventional = true
+filter_unconventional = false
 # Only matches uppercase V tags (V0.1.7+); older lowercase tags
 # (v0.1.1–v0.1.6) are excluded — their NEWS.md entries were hand-written.
 tag_pattern = "V[0-9]+\\.[0-9]+\\.[0-9]+"
 
 commit_preprocessors = [
     { pattern = ' \(#(\d+)\)', replace = ' ([#$1](https://github.com/AI-SDC/ACRO-R/pull/$1))' },
+    { pattern = 'Signed-off-by:.*', replace = '' },
+    { pattern = '\n[\s\S]*', replace = '' },
 ]
 
 commit_parsers = [
@@ -32,15 +34,16 @@ commit_parsers = [
     { message = "^docs: update changelog", skip = true },
     { message = "^docs: update citation", skip = true },
     { message = "^chore: prepare", skip = true },
-    { message = "^feat", group = "feat" },
-    { message = "^fix", group = "fix" },
-    { message = "^docs", group = "docs" },
-    { message = "^perf", group = "perf" },
-    { message = "^refactor", group = "refactor" },
-    { message = "^build", group = "build" },
-    { message = "^test", group = "test" },
-    { message = "^ci", group = "ci" },
-    { message = "^style", group = "style" },
-    { message = "^chore", group = "chore" },
-    { message = "^revert", group = "revert" },
+    { message = "^feat", group = "Features" },
+    { message = "^fix", group = "Bug Fixes" },
+    { message = "^docs", group = "Documentation" },
+    { message = "^perf", group = "Performance" },
+    { message = "^refactor", group = "Refactoring" },
+    { message = "^build", group = "Build" },
+    { message = "^test", group = "Testing" },
+    { message = "^ci", group = "CI" },
+    { message = "^style", group = "Style" },
+    { message = "^chore", group = "Chore" },
+    { message = "^revert", group = "Reverts" },
+    { message = ".*", group = "Other" },
 ]


### PR DESCRIPTION
● Closes #41.

  Adds [`git-cliff`](https://github.com/orhun/git-cliff) changelog automation. `NEWS.md` entries are generated from
  Conventional-Commits PR titles, run locally by the release manager before tagging.

  - `cliff.toml`: git-cliff config (groups by type, filters to `V*` tags, links `(#NNN)` to PRs, skips noise).
  - `CONTRIBUTING.md`: documents the PR-title convention and release command.
  - `.Rbuildignore`: excludes `cliff.toml` from the package tarball.