### PR TITLE
fixing the CI failing for conda tests

### DIFF
--- a/tests/testthat/test-install_acro.R
+++ b/tests/testthat/test-install_acro.R
@@ -1,15 +1,23 @@
-test_that("install_acro installs 'acro' in the specified environment", {
-  # Specify a temporary environment for testing
+test_that("acro is installed in the python virtual environment", {
   testthat::skip_on_cran()
   test_envname <- "test-acro-env"
 
-  # Run the install_acro function
-  install_venv(envname = test_envname)
+  # Run the acro_init function
+  acro_init(envname = test_envname)
 
-  # Check if 'acro' is installed in the test environment
+  # Check if 'acro' is installed in the correct environment
   is_installed <- reticulate::py_module_available("acro")
   expect_true(is_installed)
+})
 
-  # remove the temporary environment
-  reticulate::virtualenv_remove(test_envname, confirm = FALSE)
+test_that("acro is installed in the conda environment", {
+  testthat::skip_on_cran()
+  test_envname <- "test-acro-env"
+
+  # Run the acro_init function
+  acro_init(envname = test_envname, use_conda = TRUE)
+
+  # Check if 'acro' is installed in the correct environment
+  is_installed <- reticulate::py_module_available("acro")
+  expect_true(is_installed)
 })


### PR DESCRIPTION
Use `acro_init` instead of the specific functions `install_venv` or`install_conda` to allow the correct Python environment (conda/venv) to be chosen